### PR TITLE
fix: Removed duplicate retry logic which was causing retries on 400's…

### DIFF
--- a/cerberus-web/src/main/java/com/nike/cerberus/aws/sts/AwsStsHttpClient.java
+++ b/cerberus-web/src/main/java/com/nike/cerberus/aws/sts/AwsStsHttpClient.java
@@ -42,8 +42,8 @@ public class AwsStsHttpClient {
   private static final String DEFAULT_GET_CALLER_IDENTITY_ACTION =
       "Action=GetCallerIdentity&Version=2011-06-15";
   private static final String DEFAULT_METHOD = "POST";
-  protected static final int DEFAULT_AUTH_RETRIES = 3;
-  private static final int DEFAULT_RETRY_INTERVAL_IN_MILLIS = 200;
+  protected static final int DEFAULT_AUTH_RETRIES = 5;
+  private static final int DEFAULT_RETRY_INTERVAL_IN_MILLIS = 250;
   private static final int DEFAULT_TIMEOUT = 15;
   private static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
   private final OkHttpClient httpClient;

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-version=4.7.0
+version=4.7.2
 group=com.nike.cerberus
 springBootVersion=2.3.2.RELEASE


### PR DESCRIPTION
We had duplicate retry logic which was causing 5 retries on 400 response codes and 15 retries on 500 response codes to the AWS STS endpoint. Removed the duplicate logic so we no longer retry on 400's and only retry 5 times for 500 responses. 