### PR TITLE
Fix historical file download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,6 @@ allprojects {
 
 
   repositories {
-    jcenter()
     mavenCentral()
     google()
     maven {

--- a/cerberus-dashboard/src/actions/versionHistoryBrowserActions.js
+++ b/cerberus-dashboard/src/actions/versionHistoryBrowserActions.js
@@ -143,7 +143,6 @@ export function downloadSecureFileVersion(path, versionId, token) {
         url: `/v1/secure-file/${path}`,
         headers: {
             'X-Cerberus-Token': token,
-            'Accept': 'application/octet-stream'
         },
         responseType: 'blob',
         timeout: 60 * 1000 // 1 minute
@@ -161,7 +160,8 @@ export function downloadSecureFileVersion(path, versionId, token) {
                 let reader = new window.FileReader();
                 reader.readAsArrayBuffer(response.data);
                 reader.onload = function () {
-                    downloadjs(reader.result, path.split('/').slice(-1));
+                    let pathParts = path.split('/');
+                    downloadjs(reader.result, pathParts[pathParts.length - 1]);
                 };
                 // dispatch(updateVersionedSecureDataForPath(versionId, new Uint8Array(response.data), 'FILE'))
             })

--- a/cerberus-dashboard/src/actions/versionHistoryBrowserActions.js
+++ b/cerberus-dashboard/src/actions/versionHistoryBrowserActions.js
@@ -159,10 +159,9 @@ export function downloadSecureFileVersion(path, versionId, token) {
         return axios(request)
             .then((response) => {
                 let reader = new window.FileReader();
-                reader.readAsText(response.data);
+                reader.readAsArrayBuffer(response.data);
                 reader.onload = function () {
-                    let pathParts = path.split('/');
-                    downloadjs(reader.result, pathParts[pathParts.length - 1]);
+                    downloadjs(reader.result, path.split('/').slice(-1));
                 };
                 // dispatch(updateVersionedSecureDataForPath(versionId, new Uint8Array(response.data), 'FILE'))
             })


### PR DESCRIPTION
Changed the way files are downloaded to binary instead of as text, which was breaking because the files are stored as blobs.
Removed jcenter from the repository list