### PR TITLE
Use the correct file size for history

### DIFF
--- a/cerberus-web/src/main/java/com/nike/cerberus/service/SecureDataService.java
+++ b/cerberus-web/src/main/java/com/nike/cerberus/service/SecureDataService.java
@@ -168,7 +168,7 @@ public class SecureDataService {
           secureData.getEncryptedBlob(),
           SecureDataVersionRecord.SecretsAction.UPDATE,
           SecureDataType.FILE,
-          sizeInBytes,
+          secureData.getSizeInBytes(),
           secureData.getLastUpdatedBy(),
           secureData.getLastUpdatedTs(),
           principal,


### PR DESCRIPTION
The old way was using the size of the new file instead of the size of the historical file.